### PR TITLE
Added Subscriber for AddedToDrawPile

### DIFF
--- a/EatYourBeetSVG/src/main/java/eatyourbeets/actions/cardManipulation/MakeTempCard.java
+++ b/EatYourBeetSVG/src/main/java/eatyourbeets/actions/cardManipulation/MakeTempCard.java
@@ -17,12 +17,24 @@ import eatyourbeets.utilities.JavaUtilities;
 
 public class MakeTempCard extends EYBActionWithCallback<AbstractCard>
 {
+    public enum Destination
+    {
+        //@Formatter: Off
+        Top,
+        Bottom,
+        Random;
+
+        public boolean IsRandom() { return this == Random; }
+        public boolean IsTop()    { return this == Top;    }
+        public boolean IsBottom() { return this == Bottom; }
+        //@Formatter: On
+    }
+
     protected final CardGroup cardGroup;
     protected boolean upgrade;
     protected boolean makeCopy;
     protected boolean cancelIfFull;
-    protected boolean randomSpot = true;
-    protected boolean toBottom;
+    protected Destination destination;
     protected AbstractCard actualCard;
 
     public MakeTempCard(AbstractCard card, CardGroup group)
@@ -31,6 +43,7 @@ public class MakeTempCard extends EYBActionWithCallback<AbstractCard>
 
         this.card = card;
         this.cardGroup = group;
+        this.destination = Destination.Random;
         UnlockTracker.markCardAsSeen(card.cardID);
 
         Initialize(1);
@@ -51,10 +64,9 @@ public class MakeTempCard extends EYBActionWithCallback<AbstractCard>
         return this;
     }
 
-    public MakeTempCard SetDestination(boolean randomSpot, boolean toBottom)
+    public MakeTempCard SetDestination(Destination destination)
     {
-        this.randomSpot = randomSpot;
-        this.toBottom = toBottom;
+        this.destination = destination;
 
         return this;
     }
@@ -82,7 +94,7 @@ public class MakeTempCard extends EYBActionWithCallback<AbstractCard>
             {
                 ShowCardAndAddToDrawPileEffect effect = GameEffects.List.Add(new ShowCardAndAddToDrawPileEffect(actualCard,
                 (float) Settings.WIDTH / 2.0F - ((25.0F * Settings.scale) + AbstractCard.IMG_WIDTH),
-                (float) Settings.HEIGHT / 2.0F, randomSpot, true, toBottom));
+                (float) Settings.HEIGHT / 2.0F, destination.IsRandom(), true, destination.IsBottom()));
 
                 // For reasons unknown ShowCardAndAddToDrawPileEffect creates a copy of the card...
                 actualCard = JavaUtilities.<AbstractCard>GetField("card", ShowCardAndAddToDrawPileEffect.class).Get(effect);

--- a/EatYourBeetSVG/src/main/java/eatyourbeets/cards/animator/series/Katanagatari/Emonzaemon.java
+++ b/EatYourBeetSVG/src/main/java/eatyourbeets/cards/animator/series/Katanagatari/Emonzaemon.java
@@ -5,6 +5,7 @@ import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.characters.AbstractPlayer;
 import com.megacrit.cardcrawl.dungeons.AbstractDungeon;
 import com.megacrit.cardcrawl.monsters.AbstractMonster;
+import eatyourbeets.actions.cardManipulation.MakeTempCard;
 import eatyourbeets.cards.animator.special.EntouJyuu;
 import eatyourbeets.cards.base.AnimatorCard;
 import eatyourbeets.cards.base.EYBAttackType;
@@ -69,7 +70,7 @@ public class Emonzaemon extends AnimatorCard implements MartialArtist
                 {
                     EffectHistory.TryActivateLimited(cardID);
                     GameActions.Bottom.MakeCardInDrawPile(new EntouJyuu())
-                    .SetDestination(false, true)
+                    .SetDestination(MakeTempCard.Destination.Bottom)
                     .SetOptions(upgraded, false);
                 }
             }

--- a/EatYourBeetSVG/src/main/java/eatyourbeets/interfaces/subscribers/OnAddedToDrawPileSubscriber.java
+++ b/EatYourBeetSVG/src/main/java/eatyourbeets/interfaces/subscribers/OnAddedToDrawPileSubscriber.java
@@ -1,5 +1,8 @@
 package eatyourbeets.interfaces.subscribers;
 
-public interface OnAddedToDrawPileSubscriber {
-    void OnAddedToDrawPile();
+import eatyourbeets.actions.cardManipulation.MakeTempCard;
+
+public interface OnAddedToDrawPileSubscriber
+{
+    void OnAddedToDrawPile(boolean visualOnly, MakeTempCard.Destination destination);
 }

--- a/EatYourBeetSVG/src/main/java/patches/soul/Soul_OnToBottomOfDeck.java
+++ b/EatYourBeetSVG/src/main/java/patches/soul/Soul_OnToBottomOfDeck.java
@@ -4,16 +4,18 @@ import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.Soul;
+import eatyourbeets.actions.cardManipulation.MakeTempCard;
 import eatyourbeets.interfaces.subscribers.OnAddedToDrawPileSubscriber;
 
-@SpirePatch(clz = Soul.class, method = "onToDeck", paramtypez = {AbstractCard.class, boolean.class, boolean.class})
-public class Soul_OnToBottomOfDeck {
+@SpirePatch(clz = Soul.class, method = "onToBottomOfDeck", paramtypez = {AbstractCard.class})
+public class Soul_OnToBottomOfDeck
+{
     @SpirePostfixPatch
     public static void Postfix(Soul soul, AbstractCard card)
     {
-        if (card != null && card instanceof OnAddedToDrawPileSubscriber)
+        if (card instanceof OnAddedToDrawPileSubscriber)
         {
-            ((OnAddedToDrawPileSubscriber) card).OnAddedToDrawPile();
+            ((OnAddedToDrawPileSubscriber) card).OnAddedToDrawPile(false, MakeTempCard.Destination.Bottom);
         }
     }
 }

--- a/EatYourBeetSVG/src/main/java/patches/soul/Soul_OnToDeck.java
+++ b/EatYourBeetSVG/src/main/java/patches/soul/Soul_OnToDeck.java
@@ -4,16 +4,18 @@ import com.evacipated.cardcrawl.modthespire.lib.SpirePatch;
 import com.evacipated.cardcrawl.modthespire.lib.SpirePostfixPatch;
 import com.megacrit.cardcrawl.cards.AbstractCard;
 import com.megacrit.cardcrawl.cards.Soul;
+import eatyourbeets.actions.cardManipulation.MakeTempCard;
 import eatyourbeets.interfaces.subscribers.OnAddedToDrawPileSubscriber;
 
 @SpirePatch(clz = Soul.class, method = "onToDeck", paramtypez = {AbstractCard.class, boolean.class, boolean.class})
-public class Soul_OnToDeck {
+public class Soul_OnToDeck
+{
     @SpirePostfixPatch
     public static void Postfix(Soul soul, AbstractCard card, boolean randomSpot, boolean visualOnly)
     {
-        if (card != null && card instanceof OnAddedToDrawPileSubscriber)
+        if (card instanceof OnAddedToDrawPileSubscriber)
         {
-            ((OnAddedToDrawPileSubscriber) card).OnAddedToDrawPile();
+            ((OnAddedToDrawPileSubscriber) card).OnAddedToDrawPile(visualOnly, randomSpot ? MakeTempCard.Destination.Random : MakeTempCard.Destination.Top);
         }
     }
 }


### PR DESCRIPTION
This patches Soul.onToDeck and Soul.onToBottomOfDeck to call AddedToDrawPile() on any card that implemented OnAddedToDrawPileSubscriber